### PR TITLE
Use `FormatDax` overloaded extension

### DIFF
--- a/Basic/Format All Measures.csx
+++ b/Basic/Format All Measures.csx
@@ -1,20 +1,41 @@
 /*
- * Title: Format All Measures  
+ * Title: Format All Measures
  *
- * Author: Matt Allington, https://exceleratorbi.com.au  
+ * Authors: Matt Allington, https://exceleratorbi.com.au
+ *          trjohnson19,    https://github.com/trjohnson19
  *
- * This script loops through all the measures in your model and calls out to daxformatter.com
- * in order to format them.
+ * This script loops through the measures in the model and queries daxformatter.com
+ * to format the measures in a batch process.
  *
- * CAUTION: If your model has many measures (> 100) please use with care, as this will perform
- * many requests against the www.daxformatter.com web service. It will take some time to run,
- * and also, we don't want to DDoS attack daxformatter.com :-)
+ * This script uses the `FormatDax` overloaded extension method introduced in TE2 2.13.0.
+ * FormatDax deprecation notice: https://docs.tabulareditor.com/te2/FormatDax.html.
  */
 
-//Format All Measures
-foreach (var m in Model.AllMeasures)
-{
-    m.Expression = FormatDax(m.Expression);
-    /* Cycle over all measures in model and format 
-    them all using DAX Formatter */
+/* Format either all measures or selected measures. */
+var _measures = Model.AllMeasures;
+//var _measures = Selected.Measures;
+
+/* Format all measures using default long lines and with a space after the function name. */
+_measures.FormatDax();
+
+/*
+ * Alternative method to customize formatting returned.
+ * `FormatDax(this IEnumerable<IDaxDependantObject> objects, bool shortFormat = false, bool? skipSpaceAfterFunctionName = null)`
+ */
+//_measures.FormatDax(false, null);
+
+/*
+ * Ensure measure text has a leading newline.
+ * Fixes issue of measure expression starting directly after `<measure name> = ` on line 1.
+ */
+foreach (var _m in _measures) {
+    _m.Expression = "\n" + _m.Expression
 }
+
+/*
+ * Deprecated `FormatDax` method for use in TE2 < 2.13.
+ *
+ * foreach (var _m in _measures) {
+ *     _m.Expression = FormatDax(_m.Expression);
+ * }
+ */


### PR DESCRIPTION
Update script to use new `FormatDax` overloaded extension method introduced in TE2 2.13.0. Remove deprecated `FormatDax` method.

Deprecation notice:
https://docs.tabulareditor.com/te2/FormatDax.html